### PR TITLE
aiortc stats implementation

### DIFF
--- a/src/vsaiortc/__init__.py
+++ b/src/vsaiortc/__init__.py
@@ -50,7 +50,7 @@ from .stats import (
     RTCTransportStats,
 )
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/vsaiortc/rtcrtpreceiver.py
+++ b/src/vsaiortc/rtcrtpreceiver.py
@@ -135,6 +135,7 @@ class StreamStatistics:
         self.max_seq: Optional[int] = None
         self.cycles = 0
         self.packets_received = 0
+        self.bytes_received = 0
 
         # jitter
         self._clockrate = clockrate
@@ -151,6 +152,7 @@ class StreamStatistics:
             packet.sequence_number, self.max_seq
         )
         self.packets_received += 1
+        self.bytes_received += len(packet.payload)
 
         if self.base_seq is None:
             self.base_seq = packet.sequence_number
@@ -285,6 +287,7 @@ class RTCRtpReceiver:
         self._enabled = True
         self.__active_ssrc: dict[int, datetime.datetime] = {}
         self.__codecs: dict[int, RTCRtpCodecParameters] = {}
+        self.__active_codec_by_ssrc: dict[int, RTCRtpCodecParameters] = {}
         self.__decoder_queue: queue.Queue = queue.Queue()
         self.__decoder_thread: Optional[threading.Thread] = None
         self.__kind = kind
@@ -365,7 +368,13 @@ class RTCRtpReceiver:
                     packetsReceived=stream.packets_received,
                     packetsLost=stream.packets_lost,
                     jitter=stream.jitter,
-                    # RTPInboundRtpStreamStats
+                    # RTCInboundRtpStreamStats
+                    bytesReceived=stream.bytes_received,
+                    mimeType=(
+                        self.__active_codec_by_ssrc[ssrc].mimeType
+                        if ssrc in self.__active_codec_by_ssrc
+                        else None
+                    ),
                 )
             )
         self.__stats.update(self.transport._get_stats())
@@ -509,6 +518,7 @@ class RTCRtpReceiver:
         if packet.ssrc not in self.__remote_streams:
             self.__remote_streams[packet.ssrc] = StreamStatistics(codec.clockRate)
         self.__remote_streams[packet.ssrc].add(packet)
+        self.__active_codec_by_ssrc[packet.ssrc] = codec
 
         # unwrap retransmission packet
         if is_rtx(codec):

--- a/src/vsaiortc/rtcrtpsender.py
+++ b/src/vsaiortc/rtcrtpsender.py
@@ -126,6 +126,7 @@ class RTCRtpSender:
         self.__octet_count = 0
         self.__packet_count = 0
         self.__rtt: Optional[float] = None
+        self.__active_codec: Optional[RTCRtpCodecParameters] = None
 
         # logging
         self.__log_debug: Callable[..., None] = lambda *args: None
@@ -184,6 +185,9 @@ class RTCRtpSender:
                 bytesSent=self.__octet_count,
                 # RTCOutboundRtpStreamStats
                 trackId=str(id(self.track)),
+                mimeType=(
+                    self.__active_codec.mimeType if self.__active_codec else None
+                ),
             )
         )
         self.__stats.update(self.transport._get_stats())
@@ -258,7 +262,7 @@ class RTCRtpSender:
                         type="remote-inbound-rtp",
                         id="remote-inbound-rtp_" + str(id(self)),
                         # RTCStreamStats
-                        ssrc=packet.ssrc,
+                        ssrc=self._ssrc,
                         kind=self.__kind,
                         transportId=self.transport._stats_id,
                         # RTCReceivedRtpStreamStats
@@ -351,6 +355,7 @@ class RTCRtpSender:
         self.__force_keyframe = True
 
     async def _run_rtp(self, codec: RTCRtpCodecParameters) -> None:
+        self.__active_codec = codec
         self.__log_debug("- RTP started")
         self.__rtp_started.set()
 

--- a/src/vsaiortc/stats.py
+++ b/src/vsaiortc/stats.py
@@ -44,7 +44,10 @@ class RTCInboundRtpStreamStats(RTCReceivedRtpStreamStats):
     metrics for the incoming RTP media stream.
     """
 
-    pass
+    bytesReceived: int = 0
+    "Total number of bytes received for this SSRC (RTP payload only)."
+    mimeType: Optional[str] = None
+    "Codec MIME type (e.g. 'audio/opus', 'video/VP8') if known."
 
 
 @dataclass
@@ -66,6 +69,8 @@ class RTCOutboundRtpStreamStats(RTCSentRtpStreamStats):
     """
 
     trackId: str
+    mimeType: Optional[str] = None
+    "Codec MIME type (e.g. 'audio/opus', 'video/VP8') if known."
 
 
 @dataclass


### PR DESCRIPTION
v0.0.12
- Add RTCInboundRtpStreamStats.bytesReceived (counted on RtpPacket payload)
- Add RTCInboundRtpStreamStats.mimeType (codec MIME for the current SSRC)
- Add RTCOutboundRtpStreamStats.mimeType (codec MIME for the active sender)
- Fix: remote-inbound-rtp stats now use self._ssrc (the outbound SSRC being reported on)
  per WebRTC spec, not packet.ssrc (the RTCP reporter's SSRC).